### PR TITLE
Durable Subscription unsubscribe should not raise error

### DIFF
--- a/lib/stan/client.rb
+++ b/lib/stan/client.rb
@@ -516,7 +516,7 @@ module STAN
       })
 
       if self.durable_name
-        unsub_req[:durableName] = self.durable_name
+        unsub_req.durableName = self.durable_name
       end
 
       raw = stan.nats.request(unsub_subject, unsub_req.to_proto, {

--- a/scripts/install_server.sh
+++ b/scripts/install_server.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-VERSION="v0.5.0"
+VERSION="v0.7.0"
 
 if [ ! "$(ls -A $HOME/nats-streaming-server)" ]; then
   mkdir -p $HOME/nats-streaming-server

--- a/spec/client_subscription_spec.rb
+++ b/spec/client_subscription_spec.rb
@@ -151,6 +151,28 @@ describe 'Client - Subscriptions' do
       end
     end
 
+    it "should be able to unsubscribe from durable subsriptions" do
+      opts = { :servers => [@s.uri] }
+      durable_sub_msgs = []
+
+      sc = STAN::Client.new
+      with_nats(opts) do |nc|
+        sc.connect("test-cluster", client_id, nats: nc)
+
+        durable_sub = sc.subscribe("foo", durable_name: "quux") do |msg|
+          durable_sub_msgs << msg
+        end
+
+        durable_queue_sub = sc.subscribe("foo", queue: "bar", durable_name: "quux") do |msg|
+          durable_queue_sub_msgs << msg
+        end
+
+        # nil means it completed successfully
+        expect(durable_sub.unsubscribe).to be nil
+        expect(durable_queue_sub.unsubscribe).to be nil
+      end
+    end
+
     it "should be able to close durable subscriptions" do
       opts = { :servers => [@s.uri] }
       acks = []


### PR DESCRIPTION
Currently, if you call `.unsubscribe` against a STAN::Client::Subscription object it raises a `TypeError` in the protobufs C-extension.

This is ... sub-optimal.  Sometimes you really _do_ want to unsubscribe from a durable.

This appears just be a gap in test coverage and a simple syntax "error."  I wrote a test to cover the case and fixed the syntax error.