### PR TITLE
Add stan scripts

### DIFF
--- a/bin/stan-dump
+++ b/bin/stan-dump
@@ -1,0 +1,20 @@
+#!/usr/bin/env ruby
+
+require 'stan/client'
+
+channel = ARGV[0]
+
+abort "Usage: stan-dump <channel>" if ARGV.count != 1
+
+opts = { servers: %w(nats://127.0.0.1:4222) }
+
+sc = STAN::Client.new
+sc.connect("test-cluster", "stan-dump", nats: opts)
+sub = sc.subscribe(channel, deliver_all_available: true) do |msg|
+  puts "CHANNEL: #{channel} | MESSAGE: (seq=#{msg.seq}) #{msg.data}"
+end
+
+sleep 0.5
+
+sub.unsubscribe
+sc.close

--- a/bin/stan-pub
+++ b/bin/stan-pub
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+
+require 'stan/client'
+
+channel = ARGV[0]
+text    = ARGV[1..-1]&.join(" ")
+
+abort "Usage: stan-pub <channel> <text>" if ARGV.count <= 1
+
+opts = { servers: %w(nats://127.0.0.1:4222) }
+
+sc = STAN::Client.new
+sc.connect("test-cluster", "stan-pub", nats: opts)
+sc.publish(channel, text)
+sc.close

--- a/bin/stan-sub
+++ b/bin/stan-sub
@@ -1,0 +1,20 @@
+#!/usr/bin/env ruby
+
+require 'stan/client'
+
+channel = ARGV[0]
+
+abort "Usage: stan-sub <channel>" if ARGV.count != 1
+
+opts = { servers: %w(nats://127.0.0.1:4222) }
+
+sc = STAN::Client.new
+sc.connect("test-cluster", "stan-watch", nats: opts)
+sub = sc.subscribe(channel) do |msg|
+  puts "CHANNEL: #{channel} | MESSAGE: (seq=#{msg.seq}) #{msg.data}"
+end
+
+$stdin.gets
+
+sub.unsubscribe
+sc.close


### PR DESCRIPTION
I really liked the `nats` scripts in the `ruby-nats` repo.  Great for testing and for understanding how the libraries are supposed to work.  In this PR I submit three scripts: `stan-pub`, `stan-sub`, and `stan-dump`.  

These scripts are super-basic and can for sure be improved (OptParse!), but this is a start...